### PR TITLE
Adds pre-commit GH Action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,20 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+    - name: set PY
+      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - uses: pre-commit/action@v1.0.1

--- a/benchmarks/fetch-sra-sequencing-runs.sh
+++ b/benchmarks/fetch-sra-sequencing-runs.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+# shellcheck disable=SC2016
 bq \
   query \
   --format json \

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ docker \
   run \
   --rm \
   --workdir /data \
-  --volume `pwd`:/data \
+  --volume "$(pwd)":/data \
   --entrypoint /bin/bash \
   --env prefix=helloworld  \
   --env reference=reference/nCoV-2019.reference.fasta \


### PR DESCRIPTION
Automatically run pre-commit on PRs. First commit should fail, second should pass as it includes an `ignore` directive to shellcheck on a failing line. 