### PR TITLE
Update ocx library to 0.9.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN pip install dnaplotlib
 RUN pip install nbconvert==6.0.7
 
 # Install onecodex_pdf export option
-RUN pip install onecodex[all,reports]==v0.9.4
+RUN pip install onecodex[all,reports]==v0.9.6
 RUN mkdir -p /usr/local/share/fonts \
     && cp /usr/local/lib/python3.8/site-packages/onecodex/assets/fonts/*.otf /usr/local/share/fonts \
     && fc-cache


### PR DESCRIPTION
* [x] fixed a bug causing an `TypeError: 'coroutine' object is not subscriptable` caused by [this issue](https://github.com/jupyter/jupyter_client/issues/637) by updating the oncodex library to 0.9.6.
* [x] re-building the image will update nexclade/pangolin