### PR TITLE
Fix median depth calculation and add to report

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SARS-CoV-2 variant calling and consensus assembly pipeline for ARTIC v3 amplicon
 docker build -t covid19 .
 ```
 
-Run the pipeline in the Docker image:
+Run the pipeline in the Docker image (note that fastq files are stored in git lfs so you may need to `git lfs pull` before executing):
 
 ```sh
 docker \
@@ -23,10 +23,10 @@ docker \
   --entrypoint /bin/bash \
   --env prefix=test-covid19 \
   --env reference=reference/nCoV-2019.reference.fasta \
-  --env input_fastq=data/twist-target-capture/RNA_control_spike_in_10_6_100k_reads.fastq.gz \
   --env primer_bed_file=reference/artic-v1/ARTIC-V3.bed \
   covid19 \
-  jobscript.sh
+  jobscript.sh \
+  data/twist-target-capture/RNA_control_spike_in_10_6_100k_reads.fastq.gz
 ```
 
 For Oxford Nanopore:
@@ -41,13 +41,11 @@ docker \
   --env prefix=test-covid19 \
   --env INSTRUMENT_VENDOR="Oxford Nanopore" \
   --env reference=reference/nCoV-2019.reference.fasta \
-  --env input_fastq=data/twist-target-capture/RNA_control_spike_in_10_6_100k_reads.fastq.gz \
   --env primer_bed_file=reference/artic-v1/ARTIC-V3.bed \
   covid19 \
-  jobscript.sh
+  jobscript.sh \
+  data/twist-target-capture/RNA_control_spike_in_10_6_100k_reads.fastq.gz
 ```
-
-This currently produces a `consensus.fa` file, a `variants.vcf`, a BAM file (`covid19.bam`), nextstrain results (`nextstrain.json`) and pangolin results (`pangolin.csv`).
 
 # Development & Testing
 

--- a/jobscript.sh
+++ b/jobscript.sh
@@ -58,7 +58,7 @@ sed -i 's/&/; /g' variants.snpeff.tsv
 # needed by report
 echo "Getting depth using samtools"
 conda run -n report \
-  samtools depth covid19.bam > snps.depth
+  samtools depth -a covid19.bam > snps.depth
 
 # Count total mapped reads (can we get this from summing snps.depth)
 conda run -n report samtools view -F 2308 covid19.bam | wc -l > total_mapped_reads.txt

--- a/report.ipynb
+++ b/report.ipynb
@@ -553,7 +553,7 @@
     "<p>This sample contained <strong>{int(total_reads):,}</strong> read{'' if total_reads == 1 else 's'}, with\n",
     "<strong>{total_mapped_reads / total_reads:.1%}</strong> mapping to the \n",
     "<a href='https://www.ncbi.nlm.nih.gov/nuccore/MN908947.3/' target='_blank'>Wuhan-Hu-1 reference</a>.\n",
-    "Reads span <strong>{cov:.0%}</strong> of the genome, with a mean depth of <strong>{mean_depth:.0f}x</strong>, and {cov_mindepth:.0%} of the genome covered at depths >{MIN_DEPTH:}x.\n",
+    "Reads span <strong>{cov:.0%}</strong> of the genome, with a mean depth of <strong>{mean_depth:.0f}x</strong>, a median depth of <strong>{median_depth:.0f}x</strong>, and {cov_mindepth:.0%} of the genome covered at depth >{MIN_DEPTH:}x.\n",
     "</p>\n",
     "\"\"\")\n",
     "\n",
@@ -952,7 +952,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -966,7 +966,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Using a sample that exposed this issue for testing, a negative control with high read depth (1.6M reads): https://app.onecodex.com/classification/4c2ae2e6b5cc40af

A diff of the `.report.json.gz` shows that this fixes the median depth reporting (and changes the mean depth exposed in the report):

![image](https://user-images.githubusercontent.com/2934664/145662141-89415fee-fd3a-4d60-927a-eed64bc8f2c1.png)

This also fixes a previously unknown issue, a warning about zero coverage bases that was not getting raised for samples like these:

![image](https://user-images.githubusercontent.com/2934664/145662153-40d12a63-12b3-480e-aee6-439b7b7f7890.png)

Added `median_depth` to the pdf report:
![image](https://user-images.githubusercontent.com/2934664/145663339-5da38601-ffff-41bb-a839-7a1407729e45.png)

vs. original report:
![image](https://user-images.githubusercontent.com/2934664/145663387-4c0ca73e-7518-4c9b-89cb-7f9849f688d8.png)
