### PR TITLE
check whether fq file is gzipped before counting lines

### DIFF
--- a/report.ipynb
+++ b/report.ipynb
@@ -154,12 +154,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# yes this is slow but it doesn't require an API call\n",
-    "# (but it would be nice to not need the fastq as this point maybe. maybe this is in the bam file?)\n",
+    "# count total reads\n",
+    "\n",
+    "def is_gz_file(filepath):  \n",
+    "    # https://stackoverflow.com/questions/3703276/how-to-tell-if-a-file-is-gzip-compressed\n",
+    "    with open(filepath, \"rb\") as test_f:\n",
+    "        return test_f.read(2) == b\"\\x1f\\x8b\"\n",
+    "\n",
     "total_reads = 0\n",
-    "with gzip.open(SAMPLE_PATH, \"rt\") as handle:\n",
-    "    for line in handle:\n",
-    "        total_reads += 1\n",
+    "\n",
+    "if is_gz_file(SAMPLE_PATH):\n",
+    "    with gzip.open(SAMPLE_PATH, \"rt\") as handle:\n",
+    "        for line in handle:\n",
+    "            total_reads += 1\n",
+    "else:\n",
+    "    with open(SAMPLE_PATH, \"rt\") as handle:\n",
+    "        for line in handle:\n",
+    "            total_reads += 1\n",
+    "\n",
     "total_reads = total_reads / 4"
    ]
   },
@@ -953,7 +965,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -967,7 +979,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The results notebook assumes a gzipped fastq file, but SRA returns a plain fastq file.
Invocation that raised the issue:
`orbiter run --input-file sra://onecodex/SRR16128354.fastq --script-path /Users/scott.fay/projects/sars-cov-2/jobscript.sh --fetch-outputs covid19_report_v0.4.5:6`