### PR TITLE
Add automated CI deploy with env support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo.
+*       @clausmith @audy

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
-    - uses: pre-commit/action@v1.0.1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,35 @@
+name: publish-to-quay
+on:
+  push:
+    branches:
+      - master
+env:
+  REPOSITORY: quay.io/refgenomics/covid19
+  TAG: latest
+
+jobs:
+  publish-to-quay:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Show the secret
+        run: |
+          echo "Super secret value: ${{ secrets.SUPER_SECRET_VALUE }}"
+      - name: Login to Quay
+        shell: bash
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} quay.io --password-stdin
+
+      - name: Docker build
+        shell: bash
+        run: |
+          export DOCKER_BUILDKIT=1
+          docker build \
+            -t ${REPOSITORY}:${TAG} \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --cache-from ${REPOSITORY}:${TAG} .
+
+      - name: Push to quay
+        shell: bash
+        run: |
+          docker push ${REPOSITORY}:${TAG}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,18 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
           lfs: true
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
       - name: Cache virtualenv
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         id: cache-pip
         with:
           path: venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
Adding an automated build and deploy of the docker image to quay (only the latest tag for now).
The deployment only occurs when merging to the `master` branch and due to using a GitHub environment to protect the secrets, it needs additional approval upon being run.
Also introducing code owners to limit valid PR approvals.