### PR TITLE
Adds support for an optional additional logo in the PDF

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: zimports
         exclude: ^migrations/
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.1
     hooks:
       - id: flake8

--- a/jobscript.sh
+++ b/jobscript.sh
@@ -6,6 +6,7 @@ sample_filename="${1}"
 
 : "${INSTRUMENT_VENDOR:=Illumina}"
 : "${ONE_CODEX_REPORT_FILENAME:=report.pdf}"
+: "${ONE_CODEX_REPORT_LOGO:=}"
 : "${ARTIC_PRIMER_VERSION:=4.1}"
 : "${CONSENSUS_MASK_DEPTH:=10}"
 
@@ -99,7 +100,7 @@ cp /reference/aa_codes.txt .
 echo "Generating notebook!"
 
 #shellcheck disable=SC1000-SC9999
-RESULTS_DIR="$(pwd)" SAMPLE_PATH="${sample_filename}" PYTHONWARNINGS="ignore" GIT_DIR="/.git" GIT_WORK_TREE="/" INSTRUMENT_VENDOR="${INSTRUMENT_VENDOR}" ONE_CODEX_REPORT_FILENAME="${ONE_CODEX_REPORT_FILENAME}" ARTIC_PRIMER_VERSION="${ARTIC_PRIMER_VERSION}" conda run -n jobscript-env jupyter nbconvert --execute --to onecodex_pdf --ExecutePreprocessor.timeout=-1 --output="${ONE_CODEX_REPORT_FILENAME}" --output-dir="." report.ipynb
+RESULTS_DIR="$(pwd)" SAMPLE_PATH="${sample_filename}" PYTHONWARNINGS="ignore" GIT_DIR="/.git" GIT_WORK_TREE="/" INSTRUMENT_VENDOR="${INSTRUMENT_VENDOR}" ONE_CODEX_REPORT_FILENAME="${ONE_CODEX_REPORT_FILENAME}" ONE_CODEX_REPORT_LOGO="${ONE_CODEX_REPORT_LOGO}" ARTIC_PRIMER_VERSION="${ARTIC_PRIMER_VERSION}" conda run -n jobscript-env jupyter nbconvert --execute --to onecodex_pdf --ExecutePreprocessor.timeout=-1 --output="${ONE_CODEX_REPORT_FILENAME}" --output-dir="." report.ipynb
 
 echo "Removing unnecessary files"
 rm -f aa_codes.txt \

--- a/report.ipynb
+++ b/report.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "from Bio import SeqIO\n",
     "from IPython.display import HTML\n",
-    "from onecodex.notebooks.report import set_style, title\n",
+    "from onecodex.notebooks.report import set_logo, set_style, title\n",
     "import onecodex\n",
     "from pathlib import Path\n",
     "\n",
@@ -34,7 +34,7 @@
     "import dnaplotlib as dpl\n",
     "from matplotlib import gridspec\n",
     "import matplotlib.ticker as mticker\n",
-    "from IPython.display import Image\n",
+    "from IPython.display import display, Image\n",
     "\n",
     "\n",
     "import warnings # to avoid printing \"FixedFormatter should only be used together with FixedLocator\"\n",
@@ -45,6 +45,18 @@
     "plt.rcParams.update({'font.family':'Fira Sans', \"font.size\": 12})\n",
     "\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logo_path = os.environ.get(\"ONE_CODEX_REPORT_LOGO\")\n",
+    "\n",
+    "if logo_path:\n",
+    "    display(set_logo(logo_path))"
    ]
   },
   {

--- a/report.ipynb
+++ b/report.ipynb
@@ -27,7 +27,7 @@
     "from Bio import SeqIO\n",
     "from IPython.display import HTML\n",
     "from onecodex.notebooks.report import set_logo, set_style, title\n",
-    "import onecodex\n",
+    "from onecodex.viz import configure_onecodex_theme\n",
     "from pathlib import Path\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
@@ -126,7 +126,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "onecodex.Api() # initialize plot embedding\n",
+    "configure_onecodex_theme() # initialize plot embedding\n",
     "pass # don't print anything"
    ]
   },


### PR DESCRIPTION
This PR adds support for an optional `ONE_CODEX_REPORT_LOGO` environment variable that, when passed a publicly accessible URL, will add the file at that path as a 120px wide logo in the top left corner of each page of the PDF report. The One Codex logo stays in the top right corner.

If the env var isn't set or is false-y, we just show the One Codex logo.