### PR TITLE
Make docker image non-root runnable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@ FROM python:3.8
 # dependencies for generating report
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-RUN pip install numpy
-
-RUN pip install pysam==0.16 biopython==1.78 PyVCF
+# install dnaplotlib for creating the genome diagram
+# hard-pin some dependencies for onecodex 0.9.6
+RUN pip install numpy pysam==0.16 biopython==1.78 PyVCF dnaplotlib onecodex[all,reports]==v0.9.6 \
+    nbconvert==5.6.1 click==8.0.4 Jinja2==3.0.3
 
 USER root
 RUN apt-get update \
     && apt-get autoclean \
-    && apt-get install -y gnupg \
+    && apt-get install -y gnupg curl \
     && curl -sL https://deb.nodesource.com/setup_14.x  | bash - \
     && apt-get install -y nodejs \
     unzip \
@@ -20,20 +21,20 @@ RUN apt-get update \
 
 RUN npm install -g --unsafe-perm vega vega-lite vega-cli canvas
 
-RUN apt-get update && apt-get install -y curl
+WORKDIR /opt
 
 # install Conda
 RUN curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
   > Miniconda3-latest-Linux-x86_64.sh \
   && yes \
-  | bash Miniconda3-latest-Linux-x86_64.sh -b
+  | bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/miniconda3
 
 # put system path first so that conda doesn't override python
-ENV PATH=$PATH:/root/miniconda3/bin/
+ENV PATH=$PATH:/opt/miniconda3/bin/
 
 # install environment's dependencies
-COPY environment.yml /
-RUN conda env create -f environment.yml
+COPY environment.yml /opt/
+RUN conda env create -f /opt/environment.yml
 
 # install artic into conda environment "artic"
 RUN git clone https://github.com/artic-network/fieldbioinformatics.git \
@@ -42,10 +43,6 @@ RUN git clone https://github.com/artic-network/fieldbioinformatics.git \
       	&& conda env create -f environment.yml \
         && conda run -n artic python setup.py install \
         && conda clean -a
-
-
-# install dnaplotlib for creating the genome diagram
-RUN pip install dnaplotlib
 
 # install snpeff
 RUN curl -k -L https://sourceforge.net/projects/snpeff/files/snpEff_v4_5covid19_core.zip/download --output snpEff_v4_5covid19_core.zip\
@@ -63,7 +60,6 @@ COPY /reference/vcf_filter.edited.py /root/miniconda3/envs/artic/lib/python3.6/s
 RUN mkdir /primer_schemes
 COPY /reference/primer_schemes/ /primer_schemes/
 
-
 # install pangolin into conda environment "pangolin"
 RUN git clone https://github.com/cov-lineages/pangolin.git \
         && cd pangolin \
@@ -76,17 +72,10 @@ RUN git clone https://github.com/cov-lineages/pangolin.git \
 RUN curl -fsSL 'https://github.com/nextstrain/nextclade/releases/download/2.9.1/nextclade-x86_64-unknown-linux-gnu' -o '/usr/local/bin/nextclade' && chmod +x /usr/local/bin/nextclade
 RUN /usr/local/bin/nextclade dataset get --name 'sars-cov-2' --output-dir '/usr/local/bin/data/sars-cov-2'
 
-# Install onecodex_pdf export option
-RUN pip install onecodex[all,reports]==v0.9.6
+# Setup onecodex_pdf export option
 RUN mkdir -p /usr/local/share/fonts \
     && cp /usr/local/lib/python3.8/site-packages/onecodex/assets/fonts/*.otf /usr/local/share/fonts \
     && fc-cache
-
-# hard-pin some dependencies for onecodex 0.9.6
-RUN pip install \
-  nbconvert==5.6.1 \
-  click==8.0.4 \
-  Jinja2==3.0.3
 
 ADD jobscript.sh /usr/local/bin/
 ADD covid19_call_variants.sh /usr/local/bin/
@@ -95,6 +84,9 @@ ADD post_process_variants.sh /usr/local/bin/
 ADD generate_tsv.py /usr/local/bin
 ADD insert_coverage_stats.py /usr/local/bin
 ADD report.ipynb /
+
+ENV MPLCONFIGDIR /tmp
+RUN chmod -R a+rwx /reference /primer_schemes /report.ipynb
 
 # so we can include git hash in report for tracking
 COPY .git /.git


### PR DESCRIPTION
This PR adjusts the Dockerfile so that the resulting image is non-root runnable while not requiring any script changes.
The pip and apt installation commands have been aggregated for better docker image layering.